### PR TITLE
ヘッダーコンポネントの作成

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,15 @@
 import { auth } from '@/auth';
 import WelcomePage from './welcome/page';
+import Header from '@/components/Header';
 
 export default async function Home() {
   const session = await auth();
   if (!session) {
     return <WelcomePage />;
   }
-  return <div></div>;
+  return (
+    <div>
+      <Header />
+    </div>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export default async function Home() {
   }
   return (
     <div>
-      <Header />
+      <Header title={'Buzz Memo'} />
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,27 @@
+import { Mynerve } from 'next/font/google';
+import { auth } from '@/auth';
+import HeaderTitlte from './HeaderTitle';
+
+const mynerve = Mynerve({
+  subsets: ['latin'],
+  weight: '400',
+});
+
+type HeaderProps = {
+  title?: string | null;
+};
+
+export default async function Header({ title }: HeaderProps) {
+  const session = await auth();
+  const displayTitle = title ?? 'Buzz Memo';
+  const textSize = title == null ? 'text-5xl' : 'text-2xl';
+
+  return (
+    <HeaderTitlte
+      displayTitle={displayTitle}
+      textSize={textSize}
+      session={!!session}
+      fontClassName={mynerve.className}
+    />
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,8 +13,8 @@ type HeaderProps = {
 
 export default async function Header({ title }: HeaderProps) {
   const session = await auth();
-  const displayTitle = title ?? 'Buzz Memo';
-  const textSize = title == null ? 'text-5xl' : 'text-2xl';
+  const displayTitle = title ?? '';
+  const textSize = title == null ? 'text-2xl' : 'text-5xl';
 
   return (
     <HeaderTitlte

--- a/src/components/HeaderTitle.tsx
+++ b/src/components/HeaderTitle.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { ChevronLeft } from 'lucide-react';
+import { motion } from 'motion/react';
+import Link from 'next/link';
+import router from 'next/router';
+import LogoutButton from './LogOutButton';
+import LogInButton from './LogInButton';
+
+interface HeaderTitleProps {
+  displayTitle: string;
+  textSize: string;
+  session: boolean;
+  fontClassName: string;
+}
+
+const MotionLink = motion(Link);
+
+export default function HeaderTitle({
+  displayTitle,
+  textSize,
+  session,
+  fontClassName,
+}: HeaderTitleProps) {
+  return (
+    <header className="bg-[#FAF9F5] shadow-lg">
+      <div className="flex justify-between items-center h-16 max-w-xl mx-auto w-full px-4 text-[#222222]">
+        {displayTitle !== '' ? (
+          <MotionLink
+            href="/"
+            className={`${textSize} font-bold text-[#2D2C2B] ${fontClassName}  bg-[linear-gradient(90deg,#0D47A1,#1976D2,#42A5F5,#64B5F6,#0D47A1)]
+        bg-[length:200%_200%]
+        bg-clip-text text-transparent
+        select-none
+    
+        /* Animates the gradient background position */
+        animate-rainbow`}
+            whileHover={{
+              scale: 1.1,
+              rotate: -1,
+              y: -2,
+              color: '#A68A64',
+            }}
+            transition={{ type: 'spring', stiffness: 300 }}
+          >
+            {displayTitle}
+          </MotionLink>
+        ) : (
+          <ChevronLeft
+            size={24}
+            className={`cursor-pointer ${fontClassName}`}
+            onClick={() => router.back()}
+          />
+        )}
+
+        <nav>{session ? <LogoutButton /> : <LogInButton />}</nav>
+      </div>
+    </header>
+  );
+}

--- a/src/components/LogInButton.tsx
+++ b/src/components/LogInButton.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { signIn } from 'next-auth/react';
+import { LogIn } from 'lucide-react';
+
+export default function LogInButton() {
+  return (
+    <button
+      onClick={() => signIn()}
+      className="flex items-center gap-2 text-blue-600 hover:text-blue-800 text-md font-medium cursor-pointer"
+    >
+      <LogIn size={20} />
+      ログイン
+    </button>
+  );
+}

--- a/src/components/LogOutButton.tsx
+++ b/src/components/LogOutButton.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { signOut } from 'next-auth/react';
+import { LogOut } from 'lucide-react';
+
+export default function LogoutButton() {
+  return (
+    <button
+      onClick={() => signOut()}
+      className="flex items-center gap-2 text-blue-600 hover:text-blue-800 text-md font-medium cursor-pointer"
+    >
+      <LogOut size={20} />
+      ログアウト
+    </button>
+  );
+}


### PR DESCRIPTION
## Issue
#13 

## 概要
ヘッダーはタイトル、ログインもしくはログアウトボタンで構成。
タイトル (string) は親のコンポネントから渡すことができる。
- トップページで `Buzz Memo`
- /[service]/page.tsx で `サービス名`
- /[service]/edit/page.tsx などでは `前に戻る` アイコンの表示

前に戻るアイコンはタイトルの string が空の場合に表示する。

![buzz_header_test1](https://github.com/user-attachments/assets/c9e3b387-8aaa-40c5-afaa-41ee12e462c7)

![buzz_header_test2](https://github.com/user-attachments/assets/51603f60-09a1-4c56-a657-45dd2f0d6c0c)

![buzz_header_test3](https://github.com/user-attachments/assets/9a9d8a13-5d2d-4cb8-aef7-d0a0674c8c35)

