### PR TITLE
招待されたサービスを表示するリストのコンポネントの作成

### DIFF
--- a/src/actions/services.ts
+++ b/src/actions/services.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import { RegisterService } from '@/types/registerService';
+import { Service } from '@/types/service';
 
 export async function fetchServices(userId: string) {
   const supabase = await createClient();
@@ -12,6 +13,19 @@ export async function fetchServices(userId: string) {
     .eq('created_user_id', userId);
   if (error) throw new Error(error.message);
   return data;
+}
+
+export async function fetchServicesByIdList(ids: string[]): Promise<Service[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('services')
+    .select('id, title, path')
+    .in('id', ids);
+
+  if (error) {
+    throw new Error(`[fetchServices] ${error.message}`);
+  }
+  return data ?? [];
 }
 
 export async function fetchServicesByPath(servicePath: string) {

--- a/src/app/_components/InvitedServicesList.tsx
+++ b/src/app/_components/InvitedServicesList.tsx
@@ -1,0 +1,86 @@
+import { fetchServicesByIdList } from '@/actions/services';
+import { Card, CardContent } from '@/components/ui/card';
+import { InviteWithList } from '@/types/inviteWithList';
+import { Service } from '@/types/service';
+import Link from 'next/link';
+import { ListItemDeleteButton } from './ListItemButton';
+
+interface InvitedServicesProps {
+  invites: InviteWithList[];
+  userId: string;
+  onDeleteInvite: (inviteId: string) => void;
+}
+
+export default async function InvitedServices({
+  invites,
+  userId,
+  onDeleteInvite,
+}: InvitedServicesProps) {
+  const formatStatus = (s: number) =>
+    s === 0 ? '処理中' : s === 1 ? '招待済' : s === 2 ? 'キャンセル' : '';
+
+  const invitesPerUser = invites.filter(
+    (inv) => inv.invited_user_id === userId,
+  );
+
+  if (invitesPerUser.length === 0) {
+    return <p className="text-gray-500">招待はありません。</p>;
+  }
+
+  const serviceIds = Array.from(
+    new Set(
+      invitesPerUser
+        .map((inv) => inv.invite_lists[0]?.service_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+
+  let services: Service[];
+  try {
+    services = await fetchServicesByIdList(serviceIds);
+  } catch (err: any) {
+    return <p className="text-red-600">サービス取得エラー: {err.message}</p>;
+  }
+
+  const serviceMap = Object.fromEntries(
+    services.map((svc) => [svc.id, svc]),
+  ) as Record<string, Service>;
+
+  return (
+    <div>
+      {invitesPerUser.map((inv) => {
+        const listItem = inv.invite_lists[0];
+        if (!listItem) return null;
+
+        const svc = serviceMap[listItem.service_id];
+        return (
+          <Card key={inv.id} className="bg-[#FAF9F5] mb-4">
+            <CardContent>
+              <Link
+                href={`/${svc?.path ?? ''}`}
+                className="text-xl font-semibold hover:underline cursor-pointer mb-2 block"
+              >
+                {svc?.title ?? 'Unknown Service'}
+              </Link>
+
+              <div className="flex justify-between items-center">
+                <div>
+                  <span className="text-sm text-gray-600 mr-2">
+                    ({formatStatus(inv.status)})
+                  </span>
+                  <span className="text-sm text-gray-500">
+                    {new Date(inv.expired_at).toLocaleString()}
+                  </span>
+                </div>
+                <ListItemDeleteButton
+                  onClick={() => onDeleteInvite(inv.id)}
+                  buttonText="招待削除"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/_components/InvitingServicesList.tsx
+++ b/src/app/_components/InvitingServicesList.tsx
@@ -66,7 +66,7 @@ export default function InvitingServicesList({
           );
         })
       ) : (
-        <p className="text-gray-500">(招待はありません)</p>
+        <p className="text-gray-500">招待はありません</p>
       )}
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { deleteInvite, getInvites } from '@/actions/invites';
 import InvitingServicesList from './_components/InvitingServicesList';
 import { InviteWithList } from '@/types/inviteWithList';
 import { BookmarkCheck, UserCheck, UserPlus } from 'lucide-react';
+import InvitedServices from './_components/InvitedServicesList';
 
 export default async function Home() {
   const {
@@ -49,6 +50,12 @@ export default async function Home() {
               <UserCheck className="mr-2 w-5 h-5 text-indigo-800" />
               招待されたサービス
             </h2>
+
+            <InvitedServices
+              invites={invitesReceived}
+              onDeleteInvite={handleDeleteInvite}
+              userId={userId}
+            />
 
             <h2 className="text-lg font-bold mb-2 flex items-center">
               <UserPlus className="mr-2 w-5 h-5 text-green-800" />


### PR DESCRIPTION
## Issue
#64 

## 概要
- `service id` の配列に対応するサービスの一覧を配列で返す関数の作成
-  サービスの状態 `'処理中, 招待済, キャンセル `, `expired_at`, 招待を削除するボタンの設置