### PR TITLE
ユーザーを招待するダイアログの実装

### DIFF
--- a/src/app/_components/InviteUserDialog.tsx
+++ b/src/app/_components/InviteUserDialog.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Copy, Paperclip } from 'lucide-react';
+import { ListItemInviteButton } from '@/app/_components/ListItemButton';
+
+interface InviteUserDialogProps {
+  serviceId: string;
+}
+
+export default function InviteUserDialog({ serviceId }: InviteUserDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteToken, setInviteToken] = useState('');
+  const [inviteUrl, setInviteUrl] = useState('');
+
+  const isEmailValid = (email: string) =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+  const handleOpen = () => {
+    const token = Math.random().toString().slice(2);
+    const url = `${window.location.origin}/invite/${token}`;
+    setInviteToken(token);
+    setInviteUrl(url);
+    setIsOpen(true);
+  };
+
+  const handleCopyUrl = () => {
+    navigator.clipboard.writeText(inviteUrl);
+  };
+
+  const handleCreateMail = () => {
+    console.log(
+      'send invite to',
+      inviteEmail,
+      'with token',
+      inviteToken,
+      'for service',
+      serviceId,
+    );
+    setIsOpen(false);
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          setInviteEmail('');
+          setInviteToken('');
+          setInviteUrl('');
+        }
+        setIsOpen(open);
+      }}
+    >
+      <DialogTrigger asChild>
+        <ListItemInviteButton onClick={handleOpen} buttonText="招待する" />
+      </DialogTrigger>
+      <DialogContent className="bg-[#F0EEE6] fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full max-w-md">
+        <DialogHeader>
+          <DialogTitle>ユーザーを招待する</DialogTitle>
+          <DialogDescription>招待メールを作成します</DialogDescription>
+        </DialogHeader>
+        <div className="px-4 py-4 space-y-4">
+          <label className="block text-sm font-medium text-gray-700">
+            招待先メールアドレス
+          </label>
+          <input
+            type="email"
+            placeholder="email@example.com"
+            value={inviteEmail}
+            onChange={(e) => setInviteEmail(e.target.value)}
+            className="w-full px-3 py-2 border rounded"
+          />
+          {inviteEmail && !isEmailValid(inviteEmail) && (
+            <p className="text-sm text-red-500">
+              有効なメールアドレスを入力してください
+            </p>
+          )}
+          <button
+            onClick={handleCreateMail}
+            disabled={!inviteEmail || !isEmailValid(inviteEmail)}
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded disabled:bg-gray-400"
+          >
+            招待する
+          </button>
+          <div className="mt-2 flex justify-center">
+            <button
+              type="button"
+              onClick={handleCopyUrl}
+              className="flex items-center space-x-1 text-sm text-gray-600 hover:text-gray-800"
+            >
+              <Paperclip className="w-4 h-4" />
+              <span>リンクをコピー</span>
+            </button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/_components/InviteUserDialog.tsx
+++ b/src/app/_components/InviteUserDialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogDescription,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { Copy, Paperclip } from 'lucide-react';
+import { Paperclip } from 'lucide-react';
 import { ListItemInviteButton } from '@/app/_components/ListItemButton';
 
 interface InviteUserDialogProps {
@@ -92,7 +92,7 @@ export default function InviteUserDialog({ serviceId }: InviteUserDialogProps) {
           >
             招待する
           </button>
-          <div className="mt-2 flex justify-center">
+          <div className="mt-2 flex justify-end">
             <button
               type="button"
               onClick={handleCopyUrl}

--- a/src/app/_components/registerd_service_list/RegisteredServiceTitle.tsx
+++ b/src/app/_components/registerd_service_list/RegisteredServiceTitle.tsx
@@ -19,9 +19,11 @@ export default function RegisteredServiceTitle({
         color: '#91AFBB',
       }}
       transition={{ type: 'spring', stiffness: 300 }}
-      className="inline-block"
+      className="flex-1 min-w-0"
     >
-      <span className="text-xl font-semibold">{service.title}</span>
+      <span className="block text-xl font-semibold truncate">
+        {service.title}
+      </span>
     </MotionLink>
   );
 }

--- a/src/app/_components/registerd_service_list/ServiceCard.tsx
+++ b/src/app/_components/registerd_service_list/ServiceCard.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
-import { ListItemDeleteButton, ListItemInviteButton } from '../ListItemButton';
+import { ListItemDeleteButton } from '../ListItemButton';
 import RegisteredServiceTitle from './RegisteredServiceTitle';
+import InviteUserDialog from '@/app/_components/InviteUserDialog';
 import { Service } from '@/types/service';
 
 interface ServiceCardProps {
@@ -10,10 +12,6 @@ interface ServiceCardProps {
 }
 
 export default function ServiceCard({ service }: ServiceCardProps) {
-  const handleInvite = () => {
-    console.log('invite', service.id);
-  };
-
   const handleDelete = () => {
     console.log('delete', service.id);
   };
@@ -24,10 +22,7 @@ export default function ServiceCard({ service }: ServiceCardProps) {
         <div className="flex justify-between items-center">
           <RegisteredServiceTitle service={service} />
           <div className="flex gap-4">
-            <ListItemInviteButton
-              onClick={handleInvite}
-              buttonText="招待する"
-            />
+            <InviteUserDialog serviceId={service.id} />
             <ListItemDeleteButton
               onClick={handleDelete}
               buttonText="削除する"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,7 +37,7 @@ export default async function Home() {
     <div className="bg-[#FAF9F5] min-h-screen flex flex-col">
       <Header title={'バズメモ'} />
       <main className="flex-1 flex items-start justify-center pt-12 px-4">
-        <div className="w-full max-w-lg bg-white rounded-2xl shadow-lg p-8">
+        <div className="w-full max-w-xl bg-white rounded-2xl shadow-lg p-8">
           <section className="space-y-6">
             <RegisterServiceButton userId={userId!} userEmail={userEmail!} />
             <h2 className="text-lg font-bold mb-4 mt-4 flex items-center">


### PR DESCRIPTION
## Issue
#100 

## 概要
- ユーザーが招待するボタンをクリックした際に、email を入力する input、 招待するボタン、トークン付きのURLをコピペできるボタンを設置
- email かどうかバリデーションの作成


![buzz_memo_invite](https://github.com/user-attachments/assets/6326e6c0-8e9f-490c-bf32-f99e2d8ddb3e)


