### PR TITLE
トークン付き URL をクリックしたユーザー用ページの作成

### DIFF
--- a/src/actions/invites.ts
+++ b/src/actions/invites.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import { createClient } from '@/lib/supabase/server';
 import { InviteWithList } from '@/types/inviteWithList';
 
@@ -18,13 +20,21 @@ export async function getInvites(): Promise<InviteWithList[]> {
 export async function updateInvite(
   userId: string,
   token: string,
+  invitedUserEmail: string,
 ): Promise<boolean> {
   const supabase = await createClient();
   const { error } = await supabase
     .from('invite')
-    .update({ invited_user_id: userId, status: 1 })
+    .update({
+      invited_user_id: userId,
+      invited_user_email: invitedUserEmail,
+      status: 1,
+    })
     .eq('token', token);
-
-  if (error) return false;
+  if (error) {
+    console.log(error);
+    throw error;
+  }
+  console.log(`success ${token} ${userId} ${invitedUserEmail}`);
   return true;
 }

--- a/src/actions/invites.ts
+++ b/src/actions/invites.ts
@@ -24,6 +24,7 @@ export async function updateInvite(
     .from('invite')
     .update({ invited_user_id: userId, status: 1 })
     .eq('token', token);
+
   if (error) return false;
   return true;
 }

--- a/src/actions/invites.ts
+++ b/src/actions/invites.ts
@@ -15,7 +15,15 @@ export async function getInvites(): Promise<InviteWithList[]> {
   return data;
 }
 
-export async function deleteInvite(inviteId: string) {
+export async function updateInvite(
+  userId: string,
+  token: string,
+): Promise<boolean> {
   const supabase = await createClient();
-  await supabase.from('invite').delete().eq('id', inviteId);
+  const { error } = await supabase
+    .from('invite')
+    .update({ invited_user_id: userId, status: 1 })
+    .eq('token', token);
+  if (error) return false;
+  return true;
 }

--- a/src/actions/invites_client.ts
+++ b/src/actions/invites_client.ts
@@ -19,12 +19,13 @@ export async function getInviteListByServiceId(serviceId: string) {
 export async function insertInvite(
   listId: string,
   inviteToken: string,
-  inviteEmail: string,
+  invitedUserEmail: string,
 ) {
   const supabase = createClient();
   const { error } = await supabase.from('invite').insert({
     invite_list_id: listId,
-    invited_user_id: inviteEmail,
+    invited_user_id: null,
+    invited_user_email: invitedUserEmail,
     token: inviteToken,
     status: 0,
     expired_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),

--- a/src/actions/invites_client.ts
+++ b/src/actions/invites_client.ts
@@ -4,3 +4,30 @@ export async function deleteInvite(inviteId: string) {
   const supabase = createClient();
   await supabase.from('invite').delete().eq('id', inviteId);
 }
+
+export async function getInviteListByServiceId(serviceId: string) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('invite_lists')
+    .select('id')
+    .eq('service_id', serviceId)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+export async function insertInvite(
+  listId: string,
+  inviteToken: string,
+  inviteEmail: string,
+) {
+  const supabase = createClient();
+  const { error } = await supabase.from('invite').insert({
+    invite_list_id: listId,
+    invited_user_id: inviteEmail,
+    token: inviteToken,
+    status: 0,
+    expired_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  });
+  if (error) throw error;
+}

--- a/src/app/_components/registerd_service_list/ServiceCard.tsx
+++ b/src/app/_components/registerd_service_list/ServiceCard.tsx
@@ -22,7 +22,7 @@ export default function ServiceCard({ service }: ServiceCardProps) {
         <div className="flex justify-between items-center">
           <RegisteredServiceTitle service={service} />
           <div className="flex gap-4">
-            <InviteUserDialog />
+            <InviteUserDialog service={service} />
             <ListItemDeleteButton
               onClick={handleDelete}
               buttonText="削除する"

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { updateInvite } from '@/actions/invites';
 import { createClient } from '@/lib/supabase/server';
+import Header from '@/components/Header';
 
 type InvitePageProps = {
   params: Promise<{ token: string }>;
@@ -18,9 +19,9 @@ export default async function InvitePage({ params }: InvitePageProps) {
 
   return (
     <>
+      <Header title={'バズメモ'} />
       <main className="mx-auto max-w-xl p-6">
         <h1 className="text-2xl font-bold">サービスに招待されました</h1>
-
         {user ? (
           <></>
         ) : (

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from 'next/navigation';
+import { updateInvite } from '@/actions/invites';
+import { createClient } from '@/lib/supabase/server';
+
+type InvitePageProps = {
+  params: Promise<{ token: string }>;
+};
+
+export default async function InvitePage({ params }: InvitePageProps) {
+  const {
+    data: { user },
+  } = await (await createClient()).auth.getUser();
+
+  if (user?.email) {
+    updateInvite(user.email, (await params).token);
+    redirect('/');
+  }
+
+  return (
+    <>
+      <main className="mx-auto max-w-xl p-6">
+        <h1 className="text-2xl font-bold">サービスに招待されました</h1>
+
+        {user ? (
+          <></>
+        ) : (
+          <>
+            <span>ログインしてください。</span>
+          </>
+        )}
+      </main>
+    </>
+  );
+}

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -12,9 +12,13 @@ export default async function InvitePage({ params }: InvitePageProps) {
     data: { user },
   } = await (await createClient()).auth.getUser();
 
+  console.log(
+    `update invite: ${user?.id} ${user?.email} ${(await params).token}`,
+  );
   if (user?.email) {
-    updateInvite(user.email, (await params).token);
-    redirect('/');
+    try {
+      await updateInvite(user.email, (await params).token);
+    } catch (e) {}
   }
 
   return (

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,7 +1,7 @@
-import { redirect } from 'next/navigation';
 import { updateInvite } from '@/actions/invites';
 import { createClient } from '@/lib/supabase/server';
 import Header from '@/components/Header';
+import { redirect } from 'next/navigation';
 
 type InvitePageProps = {
   params: Promise<{ token: string }>;
@@ -10,15 +10,18 @@ type InvitePageProps = {
 export default async function InvitePage({ params }: InvitePageProps) {
   const {
     data: { user },
+    error: authError,
   } = await (await createClient()).auth.getUser();
 
-  console.log(
-    `update invite: ${user?.id} ${user?.email} ${(await params).token}`,
-  );
-  if (user?.email) {
-    try {
-      await updateInvite(user.email, (await params).token);
-    } catch (e) {}
+  if (authError) {
+    console.error('auth.getUser() error:', authError);
+  }
+
+  const token = (await params).token;
+  if (user?.id && user.email) {
+    const successfullyInvited = await updateInvite(user.id, token, user.email);
+    if (successfullyInvited) {
+    }
   }
 
   return (

--- a/src/components/LogInButton.tsx
+++ b/src/components/LogInButton.tsx
@@ -4,7 +4,7 @@ import { LogIn } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { createClient } from '@/lib/supabase/client';
 
-const MotionLogIn = motion(LogIn);
+const MotionLogIn = motion.create(LogIn);
 
 export default function LogInButton() {
   const buttonVariants = {

--- a/src/components/LogOutButton.tsx
+++ b/src/components/LogOutButton.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion';
 import { createClient } from '@/lib/supabase/client';
 import { useRouter } from 'next/navigation';
 
-const MotionLogOut = motion(LogOut);
+const MotionLogOut = motion.create(LogOut);
 
 export default function LogoutButton() {
   const router = useRouter();

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,7 +2,7 @@
 # https://supabase.com/docs/guides/local-development/cli/config
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "buzz_memo_service"
+project_id = "buzz_memo"
 
 [api]
 enabled = true

--- a/supabase/migrations/20250510012704_prevent_self_invite_trigger.sql
+++ b/supabase/migrations/20250510012704_prevent_self_invite_trigger.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION public.prevent_self_invite()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.invited_user_id = (
+       SELECT created_user_id
+         FROM public.invite_lists
+        WHERE id = NEW.invite_list_id
+     )
+  THEN
+    RAISE EXCEPTION 'Cannot invite yourself to your own list';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER check_no_self_invite
+  BEFORE INSERT OR UPDATE ON public.invite
+  FOR EACH ROW
+  EXECUTE FUNCTION public.prevent_self_invite();


### PR DESCRIPTION
## Issue
#113 

## 概要
- `public.invite` に `invited_user_email` を追加
- RLS で招待を受けたユーザーのみ更新可能な RLS を作成
     - status が 0 (処理中) のカラムが更新の対象
     - 更新後の status は 1 でなければならない
     - 更新後の invited_user_id は 現在ログイン中のユーザーの id と同じ でなければならない
     - 更新後の invited_user_email は 現在ログイン中の JWT の email と同じ でなければならない

```sql
CREATE POLICY "招待受託者のみ更新可"
  ON public.invite
  FOR UPDATE
  USING (
    status = 0
  )
  WITH CHECK (
    status = 1
    AND invited_user_id    = auth.uid()::text
    AND invited_user_email = auth.jwt() ->> 'email'
  );

```