### PR TITLE
フッターのレイアウトを修正する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "motion": "^12.9.4",
         "next": "^15.3.1",
         "react": "^19.1.0",
+        "react-icons": "^5.5.0",
         "resend": "^4.5.1",
         "tailwind-merge": "^3.2.0"
       },
@@ -9775,6 +9776,14 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "motion": "^12.9.4",
     "next": "^15.3.1",
     "react": "^19.1.0",
+    "react-icons": "^5.5.0",
     "resend": "^4.5.1",
     "tailwind-merge": "^3.2.0"
   },

--- a/src/app/[service]/edit/[id]/page.tsx
+++ b/src/app/[service]/edit/[id]/page.tsx
@@ -2,6 +2,7 @@ import { fetchBookmarkByBookmarkId } from '@/actions/bookmarks';
 import EditBookmarkForm from '../_components/EditBookmarkForm';
 import { Bookmark } from '@/types/bookmark';
 import Header from '@/components/Header';
+import Footer from '@/components/Footer';
 
 type Params = {
   params: Promise<{
@@ -35,6 +36,7 @@ export default async function EditBookmarkPage({ params }: Params) {
         {bookmark.title}
       </h1>
       <EditBookmarkForm initialData={bookmark} service={service} />
+      <Footer />
     </div>
   );
 }

--- a/src/app/[service]/edit/_components/EditBookmarkForm.tsx
+++ b/src/app/[service]/edit/_components/EditBookmarkForm.tsx
@@ -27,7 +27,7 @@ export default function EditBookmarkForm({ initialData, service }: Props) {
   };
 
   return (
-    <div className="max-w-xl mx-auto p-6 space-y-6">
+    <div className="max-w-xl mx-auto p-6 space-y-6 mb-6">
       <form
         id="updateForm"
         action={updateBookmarkByFormData}

--- a/src/app/[service]/page.tsx
+++ b/src/app/[service]/page.tsx
@@ -4,6 +4,7 @@ import { isBookmarkEditable } from '@/actions/bookmarks';
 import { createClient } from '@/lib/supabase/server';
 import BookmarkGrid from './_components/BookmarkGrid';
 import Header from '@/components/Header';
+import Footer from '@/components/Footer';
 
 type Props = {
   params: Promise<{ service: string }>;
@@ -28,6 +29,7 @@ export default async function ServicePage({ params }: Props) {
         editable={idEditable}
         servicePath={servicePath}
       />
+      <Footer />
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,21 +1,29 @@
-`use client`;
+'use client';
 import Link from 'next/link';
+import { Github } from 'lucide-react';
 
 export default function Footer() {
   return (
     <footer className="py-6 text-center text-xl text-gray-500 bg-white">
-      &copy; {new Date().getFullYear()} Buzz Memo |{' '}
-      <Link href="/terms" className="underline">
-        利用規約
-      </Link>{' '}
-      |{' '}
-      <Link href="/privacy" className="underline">
-        プライバシーポリシー
-      </Link>{' '}
-      |{' '}
-      <Link href="/contact" className="underline">
-        お問い合わせ
-      </Link>
+      <div className="mb-4 flex justify-center items-center space-x-2">
+        <Link href="/terms" className="underline">
+          利用規約
+        </Link>
+        <span className="text-gray-400">|</span>
+        <Link href="/privacy" className="underline">
+          プライバシーポリシー
+        </Link>
+        <span className="text-gray-400">|</span>
+        <a
+          href="https://github.com/kazuma-naka/buzz-memo"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-gray-700 transition-colors"
+        >
+          <Github size={24} />
+        </a>
+      </div>
+      <div>&copy; {new Date().getFullYear()} Buzz Memo</div>
     </footer>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 'use client';
 import Link from 'next/link';
-import { Github } from 'lucide-react';
+import { SiGithub } from 'react-icons/si';
 
 export default function Footer() {
   return (
@@ -20,7 +20,7 @@ export default function Footer() {
           rel="noopener noreferrer"
           className="hover:text-gray-700 transition-colors"
         >
-          <Github size={24} />
+          <SiGithub size={24} />
         </a>
       </div>
       <div>&copy; {new Date().getFullYear()} Buzz Memo</div>


### PR DESCRIPTION
## Issue
#141 

## 概要
`lucide-react` の GitHub のアイコンは deprecated になっていたため、 `react-icons` を使用する。