### PR TITLE
利用規約とプライバシーポリシーをセクションを一つの囲いに変更する

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -19,9 +19,8 @@ export default function PrivacyPage() {
               <p className="text-gray-700 leading-relaxed">
                 本ウェブサイト上で提供するサービス（以下，「本サービス」といいます。）における、ユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。
               </p>
-
-              <section className="space-y-8">
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+              <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg space-y-8">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第1条（個人情報）
                   </h2>
@@ -29,8 +28,7 @@ export default function PrivacyPage() {
                     「個人情報」とは、個人情報保護法にいう「個人情報」を指すもので、当該情報に含まれる氏名、生年月日、住所、電話番号、連絡先その他の記述等により特定の個人を識別できる情報及び容貌、指紋、声紋にかかるデータ、及び健康保険証の保険者番号などの情報を指します。
                   </p>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第2条（個人情報の収集方法）
                   </h2>
@@ -38,8 +36,7 @@ export default function PrivacyPage() {
                     当社は、ユーザーが利用登録をする際に氏名、生年月日、住所、電話番号、メールアドレス、銀行口座番号、クレジットカード番号、運転免許証番号などをお尋ねすることがあります。また、提携先（情報提供元、広告主、広告配信先など）から取引記録や決済情報を収集することがあります。
                   </p>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第3条（利用目的）
                   </h2>
@@ -54,8 +51,7 @@ export default function PrivacyPage() {
                     <li>その他、上記に付随する目的</li>
                   </ul>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第4条（利用目的の変更）
                   </h2>
@@ -63,8 +59,7 @@ export default function PrivacyPage() {
                     利用目的が変更前と関連性を有すると合理的に認められる場合に限り変更し、変更後はウェブサイト上で通知または公表します。
                   </p>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第5条（第三者提供）
                   </h2>
@@ -93,8 +88,7 @@ export default function PrivacyPage() {
                     </li>
                   </ol>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第6条（訂正・削除）
                   </h2>
@@ -102,8 +96,7 @@ export default function PrivacyPage() {
                     誤った個人情報については、当社所定の手続きにより訂正・追加・削除を請求でき、合理的と判断した場合は遅滞なく対応します。
                   </p>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第7条（利用停止等）
                   </h2>
@@ -111,8 +104,7 @@ export default function PrivacyPage() {
                     利用目的を超えた取り扱いや不正取得が疑われる場合、調査のうえ必要と判断されれば利用の停止または消去に対応します。
                   </p>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第8条（ポリシー変更）
                   </h2>
@@ -120,9 +112,8 @@ export default function PrivacyPage() {
                     法令上の義務を除き、ユーザーへの事前通知なく本ポリシーを変更でき、ウェブサイト掲載時に効力を生じます。
                   </p>
                 </div>
-              </section>
+              </div>
             </div>
-
             <div className="bg-gray-50 px-6 py-4 text-center text-sm text-gray-500">
               <p>以上</p>
             </div>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -19,9 +19,8 @@ export default function TermsPage() {
               <p className="text-gray-700 leading-relaxed">
                 この利用規約（以下，「本規約」といいます。）は，このウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものとします。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。
               </p>
-
-              <section className="space-y-8">
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+              <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg space-y-8">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第1条（適用）
                   </h2>
@@ -29,7 +28,7 @@ export default function TermsPage() {
                     本規約は，ユーザーと当社との間の本サービスの利用に関わる一切の関係に適用されるものとします。当社は本サービスに関し，本規約のほか，ご利用にあたってのルール等，各種の定め（以下，「個別規定」といいます。）をすることがあります。これら個別規定はその名称のいかんに関わらず，本規約の一部を構成するものとします。本規約の規定が個別規定と矛盾する場合には，個別規定において特段の定めなき限り，個別規定の規定が優先されるものとします。
                   </p>
                 </div>
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第2条（利用登録）
                   </h2>
@@ -47,7 +46,7 @@ export default function TermsPage() {
                     </li>
                   </ol>
                 </div>
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第3条（ユーザーIDおよびパスワードの管理）
                   </h2>
@@ -58,15 +57,15 @@ export default function TermsPage() {
                     ユーザーIDおよびパスワードの譲渡、貸与、共用は禁止されており、当社は登録情報と一致するログインをユーザー自身の利用とみなします。
                   </p>
                 </div>
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第4条（利用料金および支払方法）
                   </h2>
-                  <p className="text-gray-700 leading-relaxed mb-2">
+                  <p className="text-gray-700 leading-relaxed">
                     ユーザーは本サービスを無料で利用することができるものとします。したがって、料金の支払いに関する取り決めは一切いたしません。
                   </p>
                 </div>
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第5条（禁止事項）
                   </h2>
@@ -90,11 +89,11 @@ export default function TermsPage() {
                     <li>その他不適切と判断する行為</li>
                   </ul>
                 </div>
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第6条（本サービスの提供の停止等）
                   </h2>
-                  <p className="text-gray-700 leading-relaxed mb-2">
+                  <p className="text-gray-700 leading-relaxed">
                     当社は以下の場合、通知なく本サービスを停止または中断でき、損害賠償責任を負いません。
                   </p>
                   <ul className="list-disc list-inside space-y-1 text-gray-700">
@@ -104,12 +103,12 @@ export default function TermsPage() {
                     <li>その他提供困難と判断した場合</li>
                   </ul>
                 </div>
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第7条（利用制限および登録抹消）
                   </h2>
-                  <p className="text-gray-700 leading-relaxed mb-2">
-                    当社は以下の場合、通知なく利用制限または登録抹消ができ、損害賠償責を負いません。
+                  <p className="text-gray-700 leading-relaxed">
+                    当社は以下の場合、通知なく利用制限または登録抹消ができ、損害賠償責任を負いません。
                   </p>
                   <ul className="list-disc list-inside space-y-1 text-gray-700">
                     <li>本規約違反時</li>
@@ -120,8 +119,7 @@ export default function TermsPage() {
                     <li>その他不適切と判断した場合</li>
                   </ul>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第8条（保証の否認および免責事項）
                   </h2>
@@ -131,15 +129,11 @@ export default function TermsPage() {
                   <p className="text-gray-700 leading-relaxed mb-2">
                     当社の故意・重大な過失を除き、サービスに起因するあらゆる損害に責任を負いません。ただし、消費者契約法が適用される場合は除きます。
                   </p>
-                  <p className="text-gray-700 leading-relaxed mb-2">
-                    前項ただし書の場合でも、当社の過失（重過失除く）による損害賠償は発生月に受領した利用料を上限とし、特別な事情から生じた損害は責任を負いません。
-                  </p>
                   <p className="text-gray-700 leading-relaxed">
                     当社はユーザー間または第三者との取引・紛争等に一切責任を負いません。
                   </p>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第9条（サービス内容の変更等）
                   </h2>
@@ -147,8 +141,7 @@ export default function TermsPage() {
                     当社は事前告知の上、サービス内容の変更・追加・廃止ができ、ユーザーはこれを承諾します。
                   </p>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第10条（利用規約の変更）
                   </h2>
@@ -163,8 +156,7 @@ export default function TermsPage() {
                     変更にあたり、変更内容と発効時期を事前に通知します。
                   </p>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第11条（個人情報の取扱い）
                   </h2>
@@ -172,8 +164,7 @@ export default function TermsPage() {
                     当社は取得した個人情報をプライバシーポリシーに従い適切に取り扱います。
                   </p>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第12条（通知または連絡）
                   </h2>
@@ -181,8 +172,7 @@ export default function TermsPage() {
                     通知・連絡は当社の定める方法で行い、登録連絡先へ送信時に到達したものとみなします。
                   </p>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第13条（権利義務の譲渡の禁止）
                   </h2>
@@ -190,8 +180,7 @@ export default function TermsPage() {
                     ユーザーは当社の書面承諾なく契約上の地位および権利義務を譲渡・担保提供できません。
                   </p>
                 </div>
-
-                <div className="bg-gray-50 border border-gray-200 p-6 rounded-lg">
+                <div>
                   <h2 className="text-xl font-semibold text-gray-800 mb-2">
                     第14条（準拠法・裁判管轄）
                   </h2>
@@ -201,9 +190,8 @@ export default function TermsPage() {
                     本サービスに関する紛争は当社本店所在地の裁判所を専属的合意管轄とします。
                   </p>
                 </div>
-              </section>
+              </div>
             </div>
-
             <div className="bg-gray-50 px-6 py-4 text-center text-sm text-gray-500">
               <p>以上</p>
             </div>


### PR DESCRIPTION
## Issue
#148 

## 概要
利用規約とプライバシーポリシーがセクションごとにバックグラウンドを設定していたが１つにまとめる。

### 変更前
![before](https://github.com/user-attachments/assets/a6bd8fa1-c074-45c6-81bd-164ed4989f37)

### 変更後
![after](https://github.com/user-attachments/assets/281ff2ce-6ddc-426e-b658-329a9f7c7cdd)
